### PR TITLE
Fix issue with integer field from resource state

### DIFF
--- a/plugins/module_utils/resource.py
+++ b/plugins/module_utils/resource.py
@@ -30,9 +30,10 @@ def resolve_refs(node, context):
         return resolved
     elif isinstance(node, list):
         return [resolve_refs(i, context) for i in node]
-    else:
+    elif isinstance(node, (str, bytes, bytearray)):
         replacer = functools.partial(replace_reference, context)
         return REREG.sub(replacer, node)
+    return node
 
 
 def run(desired_state, current_state, client, state):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue when trying to resolve ref using resource state with an integer field

```
resources:
  resource_1:
    Properties:
      KeyName: ec2key-1
    Type: AWS::EC2::KeyPair
   resource_2:
     Properties:
       KeyName: ec2key-2
       IntegerProperty: 1    <====
       Tags:
        - Key: resolution
          Value: resource:resource_1.Properties.KeyName
     Type: AWS::EC2::KeyPair
```

The following exception is raised

```
resolve_refs
TypeError: expected string or bytes-like object"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
