### PR TITLE
Remove reliance on named resources.yml file

### DIFF
--- a/plugins/action/resources.py
+++ b/plugins/action/resources.py
@@ -11,8 +11,6 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         super().run(tmp, task_vars)
         module_args = copy.deepcopy(self._task.args)
-        if not module_args.get("resources"):
-            module_args["resources"] = task_vars.get("resources", {})
 
         try:
             state_file = task_vars.get("state_file")

--- a/plugins/modules/resources.py
+++ b/plugins/modules/resources.py
@@ -70,6 +70,7 @@ EXAMPLES = r"""
               Effect: Allow
               Principal:
               Service: s3.amazonaws.com
+
 # Delete Amazon EC2 key pair
 - name: Delete Amazon EC2 key pair
   pravic.pravic.resources:
@@ -78,7 +79,7 @@ EXAMPLES = r"""
       key_1:
         Type: AWS::EC2::KeyPair
         Properties:
-          KeyName: aubin-pravic
+          KeyName: test-pravic
           KeyType: rsa
 
 """

--- a/tests/integration/targets/resources/aliases
+++ b/tests/integration/targets/resources/aliases
@@ -1,0 +1,1 @@
+resources

--- a/tests/integration/targets/resources/aliases
+++ b/tests/integration/targets/resources/aliases
@@ -1,1 +1,3 @@
 resources
+cloud/aws
+zuul/pravic

--- a/tests/integration/targets/resources/defaults/main.yml
+++ b/tests/integration/targets/resources/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+resources:
+  resources_s3_bucket_1:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: resources-test-s3-bucket
+      Tags:
+        - Key: module
+          Value: resources

--- a/tests/integration/targets/resources/tasks/main.yml
+++ b/tests/integration/targets/resources/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- block:
+    - name: trying to create simple object without 'resources' parameters
+      pravic.pravic.resources:
+        state: present
+        client: aws
+      ignore_errors: true
+      register: _resource_failure
+
+    - name: Assert that module failed with proper message
+      assert:
+        that:
+          - _resource_failure is failed
+          - _resource_failure.msg == "missing required arguments: resources"
+  when: resources is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
the action plugin no longer auto-populates the resources variable when calling module `resources`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`resources`